### PR TITLE
Opentoonz base module

### DIFF
--- a/renderchan/contrib/opentoonz.py
+++ b/renderchan/contrib/opentoonz.py
@@ -13,7 +13,13 @@ class RenderChanOpentoonzModule(RenderChanModule):
         RenderChanModule.__init__(self)
         self.conf['binary']=self.findBinary("tcomposer")
         self.conf["packetSize"]=0
-
+        # Extra params
+        self.extraParams["range"]="1"
+        self.extraParams["step"]="1"
+        self.extraParams["shrink"]="1"
+        self.extraParams["multimedia"]="0"
+        self.extraParams["maxtilesize"]="none"
+        self.extraParams["nthreads"]="all"
 
     def getInputFormats(self):
         return ["tnz"]
@@ -30,7 +36,7 @@ class RenderChanOpentoonzModule(RenderChanModule):
 
         # TODO: Progress callback
 
-        commandline=[self.conf['binary'], "-nthreads", "all", filename, "-o", os.path.join(outputPath, "image."+format)]
+        commandline=[self.conf['binary'], filename, "-o", os.path.join(outputPath, "image."+format), "-nthreads", extraParams['nthreads'],  "-step", extraParams['step'], "-shrink", extraParams['shrink'], "-multimedia", extraParams['multimedia']]
         subprocess.check_call(commandline)
 
         updateCompletion(1.0)

--- a/renderchan/contrib/opentoonz.py
+++ b/renderchan/contrib/opentoonz.py
@@ -1,0 +1,36 @@
+
+
+__author__ = 'Konstantin Dmitriev'
+
+from renderchan.module import RenderChanModule
+from renderchan.utils import which
+import subprocess
+import os
+import random
+
+class RenderChanOpentoonzModule(RenderChanModule):
+    def __init__(self):
+        RenderChanModule.__init__(self)
+        self.conf['binary']=self.findBinary("tcomposer")
+        self.conf["packetSize"]=0
+
+
+    def getInputFormats(self):
+        return ["tnz"]
+
+    def getOutputFormats(self):
+        return ["tiff" , "png"]
+
+    def render(self, filename, outputPath, startFrame, endFrame, format, updateCompletion, extraParams={}):
+
+        updateCompletion(0.0)
+
+        if not os.path.exists(outputPath):
+            os.mkdir(outputPath)
+
+        # TODO: Progress callback
+
+        commandline=[self.conf['binary'], "-nthreads", "all", filename, "-o", os.path.join(outputPath, "image."+format)]
+        subprocess.check_call(commandline)
+
+        updateCompletion(1.0)


### PR DESCRIPTION
I had to remove the analyze() function, so opentoonz dependencies will not render. But I think that not many people need it. In any case, this can be added later.

Also, _tcomposer_ has no (or maybe hidden?) Options for setting the scene resolution, so it always renders to the scene resolution tnz