### PR TITLE
fix(krita): Disable module if it fails to detect animation capabilities

### DIFF
--- a/renderchan/contrib/krita.py
+++ b/renderchan/contrib/krita.py
@@ -66,8 +66,9 @@ class RenderChanKritaModule(RenderChanModule):
 
         if rc != 0:
             print('  Krita command failed (exit code %d)!' % rc)
+            self.active = False
 
-        return True
+        return self.active
 
     def analyze(self, filename):
         info={'dependencies':[], 'width':0, 'height':0}


### PR DESCRIPTION
The animation capabilities are detected by passing "--help" option to krita binary. If this command fails (non-zero exit code), that means something is wrong with Krita's installation.