### PR TITLE
OpenToonz & Olive modules: Add configuration files for Windows

### DIFF
--- a/env/windows/olive-editor.txt
+++ b/env/windows/olive-editor.txt
@@ -1,0 +1,1 @@
+C:\Program Files\Olive\olive-editor.exe

--- a/env/windows/tcomposer.txt
+++ b/env/windows/tcomposer.txt
@@ -1,0 +1,1 @@
+C:\Program Files\OpenToonz\bin\tcomposer.exe


### PR DESCRIPTION
Those files are used in Windows distribution of RenderChan.