### PR TITLE
fix: Fix parsing paths with foreign slashes

### DIFF
--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -772,7 +772,7 @@ class RenderChan():
                         if dependency.module!=None:
                             dep_isDirty = self.parseRenderDependency(dependency, False, dryRun, force)
                         else:
-                            raise Exception("No module to render file" + dependency.getPath())
+                            raise Exception("No module to render file " + dependency.getPath())
                     else:
                         # The dependency was already submitted to graph
                         dep_isDirty = dependency.isDirty

--- a/renderchan/file.py
+++ b/renderchan/file.py
@@ -3,18 +3,13 @@ __author__ = 'Konstantin Dmitriev'
 import os.path
 import configparser
 from renderchan.module import RenderChanModule
-from renderchan.utils import float_trunc, ini_wrapper, is_true_string
+from renderchan.utils import float_trunc, ini_wrapper, is_true_string, sanitize_path
 from renderchan.metadata import RenderChanMetadata
 
 class RenderChanFile():
     def __init__(self, path, modules, projects):
 
-        if os.name == 'nt':
-            path=path.replace('/',os.sep)
-        else:
-            path = path.replace('\\', os.sep)
-
-        path = os.path.abspath(path)
+        path = os.path.abspath(sanitize_path(path))
         self.projectPath = self._findProjectRoot(path)
         self.localPath = self._findLocalPath(path)
         self.project=None
@@ -70,7 +65,8 @@ class RenderChanFile():
                     print(". . Cache found")
                     self.startFrame=int(info["startFrame"])
                     self.endFrame=int(info["endFrame"])
-                    self.dependencies=dependencies
+                    for dep in dependencies:
+                        self.dependencies.append(sanitize_path(dep))
                     if info["width"]>0:
                         self.width=str(info["width"])
                     if info["height"]>0:
@@ -78,7 +74,8 @@ class RenderChanFile():
                 else:
                     info=self.module.analyze(self.getPath())
                     if "dependencies" in info.keys():
-                        self.dependencies=list(set(info["dependencies"]))
+                        for dep in list(set(info["dependencies"])):
+                            self.dependencies.append(sanitize_path(dep))
 
                     if "startFrame" in info.keys():
                         self.startFrame=int(info["startFrame"])

--- a/renderchan/utils.py
+++ b/renderchan/utils.py
@@ -186,3 +186,12 @@ def ini_wrapper(filename):
 def is_true_string(string):
     string = string.lower()
     return string == "1" or string == "true" or string == "yes"
+
+
+def sanitize_path(path):
+    assert isinstance(path, str)
+    if os.name == 'nt':
+        path = path.replace('/', os.sep)
+    else:
+        path = path.replace('\\', os.sep)
+    return path


### PR DESCRIPTION
Fix issue with parsing files, which contain foreign slashes in paths (i.e. windows slashes in unix paths).

The error was discovered by rendering Synfig files, related to this issue - https://github.com/synfig/synfig/issues/2723