### PR TITLE
SnapShot of RenderChan Implementation on Linux O.S(Ubuntu 22.04)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,19 @@ RenderChan is a smart rendering manager for animation projects. It takes a file 
 So, RenderChan constructs a list of tasks for rendering with consideration of changes in the project tree and existing renderings. The resulting list of tasks can be executed locally on the single machine or passed to renderfarm (can work with CGRU/Afanasy renderfarm - http://cgru.info/).
 
 Detailed explanation of the concept here - http://www.youtube.com/watch?v=8EkQRLS9pN0 (Remake is an early prototype of RenderChan).﻿
+
+
+__Linux Install & Use__
+(1) clone repository
+(2) Run "$nano /etc/environment" and add the following text to the file RENDERCHAN_ENVDIR="/home/your_pc/renderchan/env/linux"
+    to create an environment variable for Opentoonz
+(3) Download Latest Opentoonz app image binary and place in "/home/your_pc/renderchan/env/linux" folder
+(4) Create A tcomposer.txt file in this linux directory and add the path to your Opentoonz app image binary like
+    /home/your_pc/renderchan/env/linux/OpenToonz-1.4.0-morevna-2020.06.14-linux64-b6177.appimage
+(5) cd ../..
+(6) cd bin 
+(7) run $./renderchan '/path_to_file/' to render
+(8) create .conf files for each Animation source file to finetune rendering parameters
+    e.g. project.blend will have project.blend.conf files; shot1.kra would have shot1.kra.conf
+    as a configuration file
+ 

--- a/README.md
+++ b/README.md
@@ -10,17 +10,33 @@ So, RenderChan constructs a list of tasks for rendering with consideration of ch
 Detailed explanation of the concept here - http://www.youtube.com/watch?v=8EkQRLS9pN0 (Remake is an early prototype of RenderChan).﻿
 
 
-__Linux Install & Use__
-(1) clone repository
-(2) Run "$nano /etc/environment" and add the following text to the file RENDERCHAN_ENVDIR="/home/your_pc/renderchan/env/linux"
-    to create an environment variable for Opentoonz
-(3) Download Latest Opentoonz app image binary and place in "/home/your_pc/renderchan/env/linux" folder
-(4) Create A tcomposer.txt file in this linux directory and add the path to your Opentoonz app image binary like
-    /home/your_pc/renderchan/env/linux/OpenToonz-1.4.0-morevna-2020.06.14-linux64-b6177.appimage
-(5) cd ../..
-(6) cd bin 
-(7) run $./renderchan '/path_to_file/' to render
-(8) create .conf files for each Animation source file to finetune rendering parameters
+## Linux Install & Use
+**(1) clone repository**
+
+
+**(2) Run "$nano /etc/environment" and add the following text to the file RENDERCHAN_ENVDIR="/home/your_pc/renderchan/env/linux"
+    to create an environment variable for Opentoonz**
+
+    
+**(3) Download Latest Opentoonz app image binary and place in "/home/your_pc/renderchan/env/linux" folder**
+
+
+**(4) Create A tcomposer.txt file in this linux directory and add the path to your Opentoonz app image binary like
+    /home/your_pc/renderchan/env/linux/OpenToonz-1.4.0-morevna-2020.06.14-linux64-b6177.appimage**
+
+
+**(5) cd ../..**
+
+
+**(6) cd bin**
+
+
+**(7) Run $./renderchan '/path_to_file/' to Render**
+
+## Additional Steps
+
+**(8) create .conf files :** 
+    create .conf files for each Animation source file (.kra, .tnz,.blend) to finetune rendering parameters
     e.g. project.blend will have project.blend.conf files; shot1.kra would have shot1.kra.conf
     as a configuration file
  

--- a/env/windows/tcomposer.txt
+++ b/env/windows/tcomposer.txt
@@ -1,2 +1,2 @@
-C:\Program Files\OpenToonz\tcomposer.exe
-C:\Program Files\OpenToonz\bin\tcomposer.exe
+/snap/bin/opentoonz.tcomposer
+/snap/opentoonz/147/bin/tcomposer

--- a/projects/default/project.conf
+++ b/projects/default/project.conf
@@ -10,12 +10,12 @@ blender.cycles_samples=10
 blender.prerender_count=0
 BLENDER_VERSION=2.70
 blender.packet_size=20
-proxy_scale=0.5
+proxy_scale=1
 
 [draft]
 WIDTH=480
 HEIGHT=270
-FORMAT=avi
+FORMAT=mp4
 AUDIO_RATE=48000
 blender.cycles_samples=75
 blender.prerender_count=0
@@ -24,7 +24,7 @@ proxy_scale=1.0
 [hd]
 WIDTH=1280
 HEIGHT=720
-FORMAT=avi
+FORMAT=mp4
 AUDIO_RATE=48000
 blender.cycles_samples=75
 blender.packet_size=10

--- a/renderchan/contrib/opentoonz.py
+++ b/renderchan/contrib/opentoonz.py
@@ -12,7 +12,10 @@ import shutil
 class RenderChanOpentoonzModule(RenderChanModule):
     def __init__(self):
         RenderChanModule.__init__(self)
-        self.conf['binary']=self.findBinary("tcomposer")
+        #TO DO: create dictionary manually
+        
+        self.conf['binary']=self.findBinary("tcomposer") #method works but variable pointer is buggy/ has wrong parameters
+
         self.conf["packetSize"]=0
         # Extra params
         self.extraParams["range"]="1"
@@ -21,6 +24,7 @@ class RenderChanOpentoonzModule(RenderChanModule):
         self.extraParams["multimedia"]="0"
         self.extraParams["maxtilesize"]="none"
         self.extraParams["nthreads"]="all"
+        self.os : str = os.name
 
     def getInputFormats(self):
         return ["tnz"]
@@ -28,7 +32,15 @@ class RenderChanOpentoonzModule(RenderChanModule):
     def getOutputFormats(self):
         return ["png", "tiff", "avi"]
 
-    def render(self, filename, outputPath, startFrame, endFrame, format, updateCompletion, extraParams={}):
+    def render(self, 
+               filename : str, 
+               outputPath : str, 
+               startFrame : float, 
+               endFrame : float, 
+               format: str, 
+               updateCompletion, 
+               extraParams={}
+               ):
 
         updateCompletion(0.0)
         
@@ -39,21 +51,46 @@ class RenderChanOpentoonzModule(RenderChanModule):
             img_format=format
             img_outputPath=outputPath
         
+        # Make Output folder
         if os.path.exists(img_outputPath):
+            print("Output: ",img_outputPath)
             shutil.rmtree(img_outputPath)
         os.mkdir(img_outputPath)
 
         # TODO: Progress callback
 
-        os.chdir(os.path.dirname(self.conf['binary']))
+
+
+        # craete Empty List
+        commandline: list = []
+
+        if self.os == 'posix': # Unix-like
+            commandline=[self.findBinary("tcomposer"),'--appimage-exec', 'tcomposer', filename, "-o", os.path.join(img_outputPath, "image."+img_format), "-nthreads",extraParams['nthreads'], "-step", extraParams['step'], "-shrink", extraParams['shrink'], "-multimedia", extraParams['multimedia']]
         
-        commandline=[self.conf['binary'], filename, "-o", os.path.join(img_outputPath, "image."+img_format), "-nthreads", extraParams['nthreads'], "-step", extraParams['step'], "-shrink", extraParams['shrink'], "-multimedia", extraParams['multimedia']]
-        subprocess.check_call(commandline)
-        
+        elif self.os == "nt":
+            # Windows specofic code
+            os.chdir(os.path.dirname(self.conf['binary']))
+            commandline=[self.conf['binary'], filename, "-o", os.path.join(img_outputPath, "image."+img_format), "-nthreads", extraParams['nthreads'], "-step", extraParams['step'], "-shrink", extraParams['shrink'], "-multimedia", extraParams['multimedia']]
+  
+
+        # Error Catcher
+        try:        
+            subprocess.check_output(commandline)
+
+        except subprocess.CalledProcessError as e:
+            print(e)
+
+
+
         if format == "avi":
             #TODO: Detect frame rate!
             commandline=[self.findBinary("ffmpeg"), "-r", "24", "-f", "image2", "-i", os.path.join(img_outputPath, "image.%04d."+img_format), "-c:v", "libx264", outputPath]
-            subprocess.check_call(commandline)
-            shutil.rmtree(img_outputPath)
+            
+            try:
+                subprocess.check_call(commandline)
+                shutil.rmtree(img_outputPath)
+            except subprocess.CalledProcessError as e:
+                print(e)
+                exit
 
         updateCompletion(1.0)

--- a/renderchan/module.py
+++ b/renderchan/module.py
@@ -68,25 +68,34 @@ class RenderChanModuleManager():
 class RenderChanModule():
     imageExtensions = ['png','exr']
     def __init__(self):
-        self.conf = {}
-        self.conf['binary']=""
+        # Create A Data Structure for Config files
+        self.conf : dict = {"binary" : "", # pointer to required binary for current rendering
+                            "packetSize" : 20,
+                            "compatVersion" : 1,
+                            "extraParams": None,
+                            "maxNbCores": 0
+                            }
+        
+        #self.conf['binary']=""
         #TODO: "packetSize" should be renamed to "extra_params" and merged with self.extraParams?
-        self.conf["packetSize"]=20
-        self.conf["compatVersion"]=1
-        self.conf["maxNbCores"]=0
+        #self.conf["packetSize"]=20
+        #self.conf["compatVersion"]=1
+        #self.conf["maxNbCores"]=0
 
         # Extra params - additional rendering parameters. supplied through the project.conf and
         # file-specific .conf files.
         #TODO: ExtraParams should be registered in a special way
         #TODO:    So, if a module registers its own extra param we should now it isn't already registered as global extraParam.
-        self.extraParams={}
+        self.extraParams : dict = { "use_own_dimensions" : "0",
+                                   "proxy_scale" : "1.0"
+                                   }
         #   'use_own_dimensions' - Don't use project dimensions, use image dimensions defined it the source file
         #   'proxy_scale' - Apply scale factor to resulting image. Valid only if 'use_own_dimensions' == 1.
         #  Those options are applied in RenderChanFile.getParams() - file.py.
-        self.extraParams['use_own_dimensions']='0'
-        self.extraParams['proxy_scale']='1.0'
+        #self.extraParams['use_own_dimensions']='0'
+        #self.extraParams['proxy_scale']='1.0'
 
-        self.active=False
+        self.active : bool = False
 
     def getName(self):
         return os.path.splitext(os.path.basename(inspect.getfile(self.__class__)))[0]
@@ -94,7 +103,8 @@ class RenderChanModule():
     def loadConfiguration(self):
 
         filename = os.path.join(os.path.expanduser("~"), ".config", "renderchan", "modules.conf")
-
+        # Debug Config File Name
+        #print(filename) # For debug purposes only
         if os.path.exists(filename):
 
             config = configparser.ConfigParser()
@@ -150,12 +160,20 @@ class RenderChanModule():
     def render(self, filename, outputPath, startFrame, endFrame, format, updateCompletion, extraParams={}):
         pass
         
-    def findBinary(self, name):
+    def findBinary(self, name: str) -> str:
+        
         if "RENDERCHAN_ENVDIR" in os.environ:
+            #print(os.environ) # for debug purposes only    
             envdir=os.environ.get('RENDERCHAN_ENVDIR')
+
+            # Path to Renderchan env files for windows and linux
             path=os.path.abspath(os.path.join(envdir,name+".txt"))
+            
+            # Nested Ifs? Code Smell!!!
             if os.path.exists(path):
-                binary_path=None
+                binary_path : str =None
+
+                # open the path to env config and use a loop to read the file path
                 with open(path) as f:
                     for line in f.readlines():
                         line = line.strip()
@@ -165,6 +183,7 @@ class RenderChanModule():
                             binary_path=line
                             break
                 if binary_path:
+                    print(name,": ",binary_path) # for debug purposes only
                     return binary_path
                 else:
                     print("    Cannot find path to %s package in %s." % (name, path))

--- a/renderchan/utils.py
+++ b/renderchan/utils.py
@@ -13,6 +13,7 @@ if os.name == 'nt':
 
 def which(program):
     def is_exe(fpath):
+        #print(os.name) # for debug purposes only
         if os.name=='nt':
             return os.path.isfile(fpath) or os.path.isfile(fpath+".exe") or os.path.isfile(fpath+".bat")
         else:


### PR DESCRIPTION
1. This is a quick snapshot of implementing Renderchan on Linux OS using Opentoonz morevna edition app image binary
2. tcomposer.txt is modified for linux to point to a linux directory in the env folder which contains the app image binary
3. README.md has been modified to include linux installation and use instructions 
4. opentoonz.py has been modified to use app image binary's tcomposer module on unix-like devices
5. This my codebase avoids dealing the Ubuntu snap software management issues,  when running render chan on Unix like systems. It avoids using snap opentoonz and uses morevna opentoonz app image to avoid missing dependency errors.
