### PR TITLE
chore: Replace sox/flac/mpg123/oggdec with ffmpeg, add implemet progress reporting

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -2,13 +2,9 @@
 python3 >= 3.6
 python3-sqlite
 ffmpeg
-sox
 zip
 
 == Optional: ==
-flac
-mpg123
-vorbis
 synfig
 blender
 krita

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -2,7 +2,6 @@
 python3 >= 3.6
 python3-sqlite
 ffmpeg
-zip
 
 == Optional: ==
 synfig

--- a/_release/2-release-build-packages.sh
+++ b/_release/2-release-build-packages.sh
@@ -90,7 +90,7 @@ rm -rf renderchan-${VERSION}
 # Windows
 [ -f "renderchan-1.0-alpha1-win.zip" ] || wget https://github.com/morevnaproject-org/RenderChan/releases/download/v1.0-alpha1/renderchan-1.0-alpha1-win.zip
 [ ! -d renderchan-1.0-alpha1 ] || rm -rf renderchan-1.0-alpha1
-unzip renderchan-1.0-alpha1-win.zip
+python3 -m zipfile -e renderchan-1.0-alpha1-win.zip .
 [ ! -d renderchan-${VERSION} ] || rm -rf renderchan-${VERSION}
 mv renderchan-1.0-alpha1 renderchan-${VERSION}
 rm -rf renderchan-${VERSION}/renderchan
@@ -109,7 +109,7 @@ rm -rf renderchan-${VERSION}/python
 mkdir renderchan-${VERSION}/python
 [ -f "python-3.8.10-embed-win32.zip" ] || wget https://www.python.org/ftp/python/3.8.10/python-3.8.10-embed-win32.zip
 cd renderchan-${VERSION}/python
-unzip ../../python-3.8.10-embed-win32.zip
+python3 -m zipfile -e ../../python-3.8.10-embed-win32.zip .
 cd ../..
 [ -f renderchan-${VERSION}/renderchan/desktop/renderchan.ico ] || cp -f ../../desktop/renderchan.ico renderchan-${VERSION}/renderchan/desktop/renderchan.ico
 
@@ -157,6 +157,6 @@ rm renderchan.nsi
 cd ..
 
 [ ! -f ../files/renderchan-${VERSION}-win.zip ] || rm -f ../files/renderchan-${VERSION}-win.zip
-zip -r ../files/renderchan-${VERSION}-win.zip renderchan-${VERSION}/
+python3 -m zipfile -c ../files/renderchan-${VERSION}-win.zip renderchan-${VERSION}/
 
 rm -rf renderchan-${VERSION}

--- a/renderchan/contrib/ffmpeg.py
+++ b/renderchan/contrib/ffmpeg.py
@@ -26,6 +26,7 @@ class RenderChanFfmpegModule(RenderChanModule):
             os.mkdir(outputPath)
 
         commandline=[self.conf['binary'], "-i", filename, os.path.join(outputPath,"output_%04d.png")]
-        run_ffmpeg_progress(commandline, lambda c, t: updateCompletion(min(float(c)/t, 1.0)), endFrame-startFrame+1)
+        # whole-file decode, frame count unknown - report progress by time
+        run_ffmpeg_progress(commandline, lambda c, t: updateCompletion(min(float(c)/t, 1.0)))
 
         updateCompletion(1.0)

--- a/renderchan/contrib/ffmpeg.py
+++ b/renderchan/contrib/ffmpeg.py
@@ -3,11 +3,8 @@
 __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
-from renderchan.utils import which
-from renderchan import ui
-import subprocess
+from renderchan.utils import run_ffmpeg_progress
 import os
-import random
 
 class RenderChanFfmpegModule(RenderChanModule):
     def __init__(self):
@@ -28,9 +25,7 @@ class RenderChanFfmpegModule(RenderChanModule):
         if not os.path.exists(outputPath):
             os.mkdir(outputPath)
 
-        # TODO: Progress callback
-
         commandline=[self.conf['binary'], "-i", filename, os.path.join(outputPath,"output_%04d.png")]
-        subprocess.check_call(commandline, **ui.quiet_subprocess())
+        run_ffmpeg_progress(commandline, lambda c, t: updateCompletion(min(float(c)/t, 1.0)), endFrame-startFrame+1)
 
         updateCompletion(1.0)

--- a/renderchan/contrib/flac.py
+++ b/renderchan/contrib/flac.py
@@ -11,7 +11,7 @@ class RenderChanFlacModule(RenderChanModule):
         RenderChanModule.__init__(self)
         self.conf['binary']=self.findBinary("ffmpeg")
         self.conf["packetSize"]=0
-        self.soxr=ffmpeg_has_soxr(self.conf['binary'])
+        self.soxr=False
 
     def getInputFormats(self):
         return ["flac"]
@@ -25,6 +25,7 @@ class RenderChanFlacModule(RenderChanModule):
             ui.info("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf['binary']))
             ui.info("    Please install ffmpeg package.")
             return False
+        self.soxr=ffmpeg_has_soxr(self.conf['binary'])
         self.active=True
         return True
 
@@ -35,6 +36,9 @@ class RenderChanFlacModule(RenderChanModule):
         commandline=[self.conf['binary'], "-y", "-i", filename]
         if self.soxr:
             commandline+=["-af", "aresample=resampler=soxr"]
+        else:
+            # high-quality swresample fallback when ffmpeg lacks libsoxr
+            commandline+=["-af", "aresample=resampler=swr:filter_size=64:dither_method=triangular"]
         commandline+=["-ar", extraParams["audio_rate"], outputPath]
         run_ffmpeg_progress(commandline, lambda c, t: updateCompletion(min(float(c)/t, 1.0)))
 

--- a/renderchan/contrib/flac.py
+++ b/renderchan/contrib/flac.py
@@ -3,18 +3,16 @@
 __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
-from renderchan.utils import which
+from renderchan.utils import which, ffmpeg_has_soxr
 from renderchan import ui
 import subprocess
-import os
-import random
 
 class RenderChanFlacModule(RenderChanModule):
     def __init__(self):
         RenderChanModule.__init__(self)
-        self.conf['binary']=self.findBinary("flac")
-        self.conf['sox_binary']=self.findBinary("sox")
+        self.conf['binary']=self.findBinary("ffmpeg")
         self.conf["packetSize"]=0
+        self.soxr=ffmpeg_has_soxr(self.conf['binary'])
 
     def getInputFormats(self):
         return ["flac"]
@@ -26,12 +24,7 @@ class RenderChanFlacModule(RenderChanModule):
         if which(self.conf['binary']) == None:
             self.active=False
             ui.info("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf['binary']))
-            ui.info("    Please install flac package.")
-            return False
-        if which(self.conf['sox_binary']) == None:
-            self.active=False
-            ui.info("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['sox_binary']))
-            ui.info("    Please install sox package.")
+            ui.info("    Please install ffmpeg package.")
             return False
         self.active=True
         return True
@@ -40,17 +33,12 @@ class RenderChanFlacModule(RenderChanModule):
 
         updateCompletion(0.0)
 
-        random_string = "%08d" % (random.randint(0,99999999))
-        tmpfile=outputPath+"."+random_string
-
         # TODO: Progress callback
 
-        commandline=[self.conf['binary'], "-d", filename, "-o", tmpfile]
+        commandline=[self.conf['binary'], "-y", "-i", filename]
+        if self.soxr:
+            commandline+=["-af", "aresample=resampler=soxr"]
+        commandline+=["-ar", extraParams["audio_rate"], outputPath]
         subprocess.check_call(commandline, **ui.quiet_subprocess())
-
-        commandline=[self.conf['sox_binary'], tmpfile, outputPath, "rate", "-v", extraParams["audio_rate"]]
-        subprocess.check_call(commandline, **ui.quiet_subprocess())
-
-        os.remove(tmpfile)
 
         updateCompletion(1.0)

--- a/renderchan/contrib/flac.py
+++ b/renderchan/contrib/flac.py
@@ -3,9 +3,8 @@
 __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
-from renderchan.utils import which, ffmpeg_has_soxr
+from renderchan.utils import which, ffmpeg_has_soxr, run_ffmpeg_progress
 from renderchan import ui
-import subprocess
 
 class RenderChanFlacModule(RenderChanModule):
     def __init__(self):
@@ -33,12 +32,10 @@ class RenderChanFlacModule(RenderChanModule):
 
         updateCompletion(0.0)
 
-        # TODO: Progress callback
-
         commandline=[self.conf['binary'], "-y", "-i", filename]
         if self.soxr:
             commandline+=["-af", "aresample=resampler=soxr"]
         commandline+=["-ar", extraParams["audio_rate"], outputPath]
-        subprocess.check_call(commandline, **ui.quiet_subprocess())
+        run_ffmpeg_progress(commandline, lambda c, t: updateCompletion(min(float(c)/t, 1.0)))
 
         updateCompletion(1.0)

--- a/renderchan/contrib/mp3.py
+++ b/renderchan/contrib/mp3.py
@@ -3,9 +3,8 @@
 __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
-from renderchan.utils import which, ffmpeg_has_soxr
+from renderchan.utils import which, ffmpeg_has_soxr, run_ffmpeg_progress
 from renderchan import ui
-import subprocess
 
 class RenderChanMp3Module(RenderChanModule):
     def __init__(self):
@@ -33,12 +32,10 @@ class RenderChanMp3Module(RenderChanModule):
 
         updateCompletion(0.0)
 
-        # TODO: Progress callback
-
         commandline=[self.conf['binary'], "-y", "-i", filename]
         if self.soxr:
             commandline+=["-af", "aresample=resampler=soxr"]
         commandline+=["-ar", extraParams["audio_rate"], outputPath]
-        subprocess.check_call(commandline, **ui.quiet_subprocess())
+        run_ffmpeg_progress(commandline, lambda c, t: updateCompletion(min(float(c)/t, 1.0)))
 
         updateCompletion(1.0)

--- a/renderchan/contrib/mp3.py
+++ b/renderchan/contrib/mp3.py
@@ -3,19 +3,16 @@
 __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
-from renderchan.utils import which
+from renderchan.utils import which, ffmpeg_has_soxr
 from renderchan import ui
 import subprocess
-import os
-import re
-import random
 
 class RenderChanMp3Module(RenderChanModule):
     def __init__(self):
         RenderChanModule.__init__(self)
-        self.conf['binary']=self.findBinary("mpg123")
-        self.conf['sox_binary']=self.findBinary("sox")
+        self.conf['binary']=self.findBinary("ffmpeg")
         self.conf["packetSize"]=0
+        self.soxr=ffmpeg_has_soxr(self.conf['binary'])
 
     def getInputFormats(self):
         return ["mp3"]
@@ -27,32 +24,21 @@ class RenderChanMp3Module(RenderChanModule):
         if which(self.conf['binary']) == None:
             self.active=False
             ui.info("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf['binary']))
-            ui.info("    Please install mpg123 package.")
-            return False
-        if which(self.conf['sox_binary']) == None:
-            self.active=False
-            ui.info("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['sox_binary']))
-            ui.info("    Please install sox package.")
+            ui.info("    Please install ffmpeg package.")
             return False
         self.active=True
         return True
 
     def render(self, filename, outputPath, startFrame, endFrame, format, updateCompletion, extraParams={}):
 
-        comp = 0.0
-        updateCompletion(comp)
-
-        random_string = "%08d" % (random.randint(0,99999999))
-        tmpfile=outputPath+"."+random_string
+        updateCompletion(0.0)
 
         # TODO: Progress callback
 
-        commandline=[self.conf['binary'], "-w", tmpfile, filename]
+        commandline=[self.conf['binary'], "-y", "-i", filename]
+        if self.soxr:
+            commandline+=["-af", "aresample=resampler=soxr"]
+        commandline+=["-ar", extraParams["audio_rate"], outputPath]
         subprocess.check_call(commandline, **ui.quiet_subprocess())
-
-        commandline=[self.conf['sox_binary'], tmpfile, outputPath, "rate", "-v", extraParams["audio_rate"]]
-        subprocess.check_call(commandline, **ui.quiet_subprocess())
-
-        os.remove(tmpfile)
 
         updateCompletion(1.0)

--- a/renderchan/contrib/mp3.py
+++ b/renderchan/contrib/mp3.py
@@ -11,7 +11,7 @@ class RenderChanMp3Module(RenderChanModule):
         RenderChanModule.__init__(self)
         self.conf['binary']=self.findBinary("ffmpeg")
         self.conf["packetSize"]=0
-        self.soxr=ffmpeg_has_soxr(self.conf['binary'])
+        self.soxr=False
 
     def getInputFormats(self):
         return ["mp3"]
@@ -25,6 +25,7 @@ class RenderChanMp3Module(RenderChanModule):
             ui.info("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf['binary']))
             ui.info("    Please install ffmpeg package.")
             return False
+        self.soxr=ffmpeg_has_soxr(self.conf['binary'])
         self.active=True
         return True
 
@@ -35,6 +36,9 @@ class RenderChanMp3Module(RenderChanModule):
         commandline=[self.conf['binary'], "-y", "-i", filename]
         if self.soxr:
             commandline+=["-af", "aresample=resampler=soxr"]
+        else:
+            # high-quality swresample fallback when ffmpeg lacks libsoxr
+            commandline+=["-af", "aresample=resampler=swr:filter_size=64:dither_method=triangular"]
         commandline+=["-ar", extraParams["audio_rate"], outputPath]
         run_ffmpeg_progress(commandline, lambda c, t: updateCompletion(min(float(c)/t, 1.0)))
 

--- a/renderchan/contrib/vorbis.py
+++ b/renderchan/contrib/vorbis.py
@@ -11,7 +11,7 @@ class RenderChanVorbisModule(RenderChanModule):
         RenderChanModule.__init__(self)
         self.conf['binary']=self.findBinary("ffmpeg")
         self.conf["packetSize"]=0
-        self.soxr=ffmpeg_has_soxr(self.conf['binary'])
+        self.soxr=False
 
     def getInputFormats(self):
         return ["ogg"]
@@ -25,6 +25,7 @@ class RenderChanVorbisModule(RenderChanModule):
             ui.info("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf['binary']))
             ui.info("    Please install ffmpeg package.")
             return False
+        self.soxr=ffmpeg_has_soxr(self.conf['binary'])
         self.active=True
         return True
 
@@ -35,6 +36,9 @@ class RenderChanVorbisModule(RenderChanModule):
         commandline=[self.conf['binary'], "-y", "-i", filename]
         if self.soxr:
             commandline+=["-af", "aresample=resampler=soxr"]
+        else:
+            # high-quality swresample fallback when ffmpeg lacks libsoxr
+            commandline+=["-af", "aresample=resampler=swr:filter_size=64:dither_method=triangular"]
         commandline+=["-ar", extraParams["audio_rate"], outputPath]
         run_ffmpeg_progress(commandline, lambda c, t: updateCompletion(min(float(c)/t, 1.0)))
 

--- a/renderchan/contrib/vorbis.py
+++ b/renderchan/contrib/vorbis.py
@@ -3,9 +3,8 @@
 __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
-from renderchan.utils import which, ffmpeg_has_soxr
+from renderchan.utils import which, ffmpeg_has_soxr, run_ffmpeg_progress
 from renderchan import ui
-import subprocess
 
 class RenderChanVorbisModule(RenderChanModule):
     def __init__(self):
@@ -33,12 +32,10 @@ class RenderChanVorbisModule(RenderChanModule):
 
         updateCompletion(0.0)
 
-        # TODO: Progress callback
-
         commandline=[self.conf['binary'], "-y", "-i", filename]
         if self.soxr:
             commandline+=["-af", "aresample=resampler=soxr"]
         commandline+=["-ar", extraParams["audio_rate"], outputPath]
-        subprocess.check_call(commandline, **ui.quiet_subprocess())
+        run_ffmpeg_progress(commandline, lambda c, t: updateCompletion(min(float(c)/t, 1.0)))
 
         updateCompletion(1.0)

--- a/renderchan/contrib/vorbis.py
+++ b/renderchan/contrib/vorbis.py
@@ -3,18 +3,16 @@
 __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
-from renderchan.utils import which
+from renderchan.utils import which, ffmpeg_has_soxr
 from renderchan import ui
 import subprocess
-import os
-import random
 
 class RenderChanVorbisModule(RenderChanModule):
     def __init__(self):
         RenderChanModule.__init__(self)
-        self.conf['binary']=self.findBinary("oggdec")
-        self.conf['sox_binary']=self.findBinary("sox")
+        self.conf['binary']=self.findBinary("ffmpeg")
         self.conf["packetSize"]=0
+        self.soxr=ffmpeg_has_soxr(self.conf['binary'])
 
     def getInputFormats(self):
         return ["ogg"]
@@ -25,33 +23,22 @@ class RenderChanVorbisModule(RenderChanModule):
     def checkRequirements(self):
         if which(self.conf['binary']) == None:
             self.active=False
-            ui.info("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['binary']))
-            ui.info("    Please install vorbis-tools package.")
-            return False
-        if which(self.conf['sox_binary']) == None:
-            self.active=False
-            ui.info("Module warning (%s): Cannot find '%s' executable!" % (self.getName(), self.conf['sox_binary']))
-            ui.info("    Please install sox package.")
+            ui.info("Module warning (%s): Cannot find '%s' executable." % (self.getName(), self.conf['binary']))
+            ui.info("    Please install ffmpeg package.")
             return False
         self.active=True
         return True
 
     def render(self, filename, outputPath, startFrame, endFrame, format, updateCompletion, extraParams={}):
 
-        comp = 0.0
-        updateCompletion(comp)
-
-        random_string = "%08d" % (random.randint(0,99999999))
-        tmpfile=outputPath+"."+random_string
+        updateCompletion(0.0)
 
         # TODO: Progress callback
 
-        commandline=[self.conf['binary'], filename, "-o",tmpfile]
+        commandline=[self.conf['binary'], "-y", "-i", filename]
+        if self.soxr:
+            commandline+=["-af", "aresample=resampler=soxr"]
+        commandline+=["-ar", extraParams["audio_rate"], outputPath]
         subprocess.check_call(commandline, **ui.quiet_subprocess())
-
-        commandline=[self.conf['sox_binary'], tmpfile, outputPath, "rate", "-v", extraParams["audio_rate"]]
-        subprocess.check_call(commandline, **ui.quiet_subprocess())
-
-        os.remove(tmpfile)
 
         updateCompletion(1.0)

--- a/renderchan/contrib/zip.py
+++ b/renderchan/contrib/zip.py
@@ -25,7 +25,10 @@ class RenderChanZipModule(RenderChanModule):
 
         os.mkdir(outputPath)
         with ZipFile(filename) as zip:
-            for member in zip.namelist():
+            members = zip.namelist()
+            total = len(members)
+            for i, member in enumerate(members):
                 zip.extract(member, outputPath)
+                updateCompletion(float(i+1)/total if total else 1.0)
 
         updateCompletion(1.0)

--- a/renderchan/contrib/zip.py
+++ b/renderchan/contrib/zip.py
@@ -1,11 +1,8 @@
 __author__ = 'Konstantin Dmitriev'
 
 from renderchan.module import RenderChanModule
-from renderchan.utils import which
-import subprocess
 import os
 from zipfile import ZipFile
-import random
 
 class RenderChanZipModule(RenderChanModule):
     def __init__(self):

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -12,7 +12,7 @@ from renderchan.utils import touch
 from renderchan.utils import copytree
 from renderchan.utils import link_or_copy
 from renderchan.utils import which
-from renderchan.utils import run_ffmpeg_progress as ffmpeg_progress
+from renderchan.utils import run_ffmpeg_progress
 from renderchan.utils import is_true_string
 from renderchan import ui
 import os, time
@@ -1040,7 +1040,7 @@ class RenderChan():
         taskfile.pending=False
 
     def run_ffmpeg_progress(self, cmd, total_frames, phase="Encoding"):
-        ffmpeg_progress(cmd, lambda c, t: ui.progress(phase, c, t), total_frames)
+        run_ffmpeg_progress(cmd, lambda c, t: ui.progress(phase, c, t), total_frames)
 
     def job_render(self, taskfile, format, updateCompletion, start=None, end=None, compare_time=None):
         """

--- a/renderchan/core.py
+++ b/renderchan/core.py
@@ -12,11 +12,10 @@ from renderchan.utils import touch
 from renderchan.utils import copytree
 from renderchan.utils import link_or_copy
 from renderchan.utils import which
+from renderchan.utils import run_ffmpeg_progress as ffmpeg_progress
 from renderchan.utils import is_true_string
 from renderchan import ui
 import os, time
-import re
-import tempfile
 import shutil
 import subprocess
 import zipfile
@@ -1041,28 +1040,7 @@ class RenderChan():
         taskfile.pending=False
 
     def run_ffmpeg_progress(self, cmd, total_frames, phase="Encoding"):
-        if ui.is_verbose():
-            subprocess.check_call(cmd)
-            return
-        cmd = cmd[:1] + ["-nostats", "-progress", "pipe:1"] + cmd[1:]
-        errlog = tempfile.TemporaryFile()
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=errlog)
-        frame_re = re.compile(r"frame=\s*(\d+)")
-        for line in proc.stdout:
-            m = frame_re.match(line.decode("utf-8", errors="replace").strip())
-            if m and total_frames > 0:
-                ui.progress(phase, min(int(m.group(1)), total_frames), total_frames)
-        rc = proc.wait()
-        errlog.seek(0)
-        log = errlog.read().decode("utf-8", errors="replace")
-        errlog.close()
-        # image2 demuxer stops at the first unreadable frame but still exits 0,
-        # silently producing a shorter video - treat that as a failure
-        if rc == 0 and "Could not open file" not in log and "Conversion failed" not in log:
-            return
-        for line in log.splitlines()[-10:]:
-            ui.error(line)
-        raise subprocess.CalledProcessError(rc or 1, cmd)
+        ffmpeg_progress(cmd, lambda c, t: ui.progress(phase, c, t), total_frames)
 
     def job_render(self, taskfile, format, updateCompletion, start=None, end=None, compare_time=None):
         """

--- a/renderchan/utils.py
+++ b/renderchan/utils.py
@@ -59,6 +59,7 @@ def run_ffmpeg_progress(cmd, progress, total_frames=None):
     time_re = re.compile(r"out_time_(?:ms|us)=(\d+)")
     duration_re = re.compile(r"Duration: (\d+):(\d+):(\d+\.\d+)")
     duration = None
+    last = None  # dedupe: ffmpeg emits both out_time_ms and out_time_us
     log = []
     for line in proc.stdout:
         line = line.decode("utf-8", errors="replace").strip()
@@ -75,8 +76,9 @@ def run_ffmpeg_progress(cmd, progress, total_frames=None):
                     duration = int((((h * 60) + mnt) * 60 + s) * 1000000)
             else:
                 m = time_re.match(line)
-                if m:
-                    progress(min(int(m.group(1)), duration), duration)
+                if m and m.group(1) != last:
+                    last = m.group(1)
+                    progress(min(int(last), duration), duration)
     rc = proc.wait()
     log = "\n".join(log)
     # image2 demuxer stops at the first unreadable frame but still exits 0,

--- a/renderchan/utils.py
+++ b/renderchan/utils.py
@@ -6,6 +6,7 @@ import time
 import threading
 import io
 import shutil
+import subprocess
 from renderchan import ui
 
 if os.name == 'nt':
@@ -30,6 +31,15 @@ def which(program):
             return os.path.realpath(path)
 
     return None
+
+def ffmpeg_has_soxr(binary):
+    """True if the given ffmpeg binary is built with libsoxr."""
+    try:
+        out = subprocess.check_output([binary, "-hide_banner", "-version"],
+                                      stderr=subprocess.STDOUT)
+        return b"enable-libsoxr" in out
+    except Exception:
+        return False
 
 _hardlinks_broken = False
 

--- a/renderchan/utils.py
+++ b/renderchan/utils.py
@@ -6,8 +6,8 @@ import re
 import time
 import threading
 import io
-import shutil
 import subprocess
+from collections import deque
 from renderchan import ui
 
 if os.name == 'nt':
@@ -60,10 +60,13 @@ def run_ffmpeg_progress(cmd, progress, total_frames=None):
     duration_re = re.compile(r"Duration: (\d+):(\d+):(\d+\.\d+)")
     duration = None
     last = None  # dedupe: ffmpeg emits both out_time_ms and out_time_us
-    log = []
+    # Bounded error context; "-progress" key=value spam is skipped, so the
+    # buffer keeps real ffmpeg diagnostics instead of progress lines.
+    log = deque(maxlen=100)
     for line in proc.stdout:
         line = line.decode("utf-8", errors="replace").strip()
-        log.append(line)
+        if "=" not in line:
+            log.append(line)
         if total_frames:
             m = frame_re.match(line)
             if m:

--- a/renderchan/utils.py
+++ b/renderchan/utils.py
@@ -2,6 +2,7 @@ __author__ = 'Konstantin Dmitriev'
 
 import os, shutil, errno
 import random
+import re
 import time
 import threading
 import io
@@ -40,6 +41,51 @@ def ffmpeg_has_soxr(binary):
         return b"enable-libsoxr" in out
     except Exception:
         return False
+
+def run_ffmpeg_progress(cmd, progress, total_frames=None):
+    """Run ffmpeg, reporting progress(current, total) along the way.
+
+    total_frames > 0: progress counted by frames ("frame=" lines).
+    total_frames None: progress counted by time ("out_time_*" vs input
+    Duration), for audio-only jobs where frame count is meaningless.
+    Raises CalledProcessError on failure, like check_call.
+    """
+    if ui.is_verbose():
+        subprocess.check_call(cmd)
+        return
+    cmd = cmd[:1] + ["-nostats", "-progress", "pipe:1"] + cmd[1:]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    frame_re = re.compile(r"frame=\s*(\d+)")
+    time_re = re.compile(r"out_time_(?:ms|us)=(\d+)")
+    duration_re = re.compile(r"Duration: (\d+):(\d+):(\d+\.\d+)")
+    duration = None
+    log = []
+    for line in proc.stdout:
+        line = line.decode("utf-8", errors="replace").strip()
+        log.append(line)
+        if total_frames:
+            m = frame_re.match(line)
+            if m:
+                progress(min(int(m.group(1)), total_frames), total_frames)
+        else:
+            if duration is None:
+                m = duration_re.search(line)
+                if m:
+                    h, mnt, s = int(m.group(1)), int(m.group(2)), float(m.group(3))
+                    duration = int((((h * 60) + mnt) * 60 + s) * 1000000)
+            else:
+                m = time_re.match(line)
+                if m:
+                    progress(min(int(m.group(1)), duration), duration)
+    rc = proc.wait()
+    log = "\n".join(log)
+    # image2 demuxer stops at the first unreadable frame but still exits 0,
+    # silently producing a shorter video - treat that as a failure
+    if rc == 0 and "Could not open file" not in log and "Conversion failed" not in log:
+        return
+    for line in log.splitlines()[-10:]:
+        ui.error(line)
+    raise subprocess.CalledProcessError(rc or 1, cmd)
 
 _hardlinks_broken = False
 


### PR DESCRIPTION
Drops external tool dependencies in favor of ffmpeg and the Python
standard library:

- Audio decoding (mp3, flac, ogg) now uses a single ffmpeg call
  instead of decoder + sox through a temp file. Resampling uses
  libsoxr when available, with a high-quality swresample fallback.
- Zip packing/unpacking (module and release script) uses
  `python3 -m zipfile` / `zipfile` instead of zip/unzip binaries.
- sox, flac, mpg123, vorbis-tools and zip removed from DEPENDENCIES.

## Progress reporting

- New shared `run_ffmpeg_progress()` in utils: frame-based progress
  for video encoding, time-based progress (vs input Duration) for
  audio and whole-file decoding.
- ffmpeg, flac, mp3, vorbis and zip modules now report progress
  (the old "TODO: Progress callback" is gone).
- Error log is a bounded buffer with progress spam filtered out, so
  failures print real ffmpeg diagnostics in O(1) memory.